### PR TITLE
Correct Route 53 project heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -798,7 +798,7 @@
           <!-- Removed project thumbnail image -->
           <div class="emoji">🛠️</div>
           <div class="project-content">
-            <h3>Website Hosting on GitHub and Route53</h3>
+            <h3>Website Hosting on GitHub and Route 53</h3>
             <p>This site is hosted using GitHub Pages, with a custom domain managed via Amazon Route 53. It’s a fully static HTML/CSS portfolio built from scratch, designed to highlight my AWS DevOps work and learning journey in security and AI.</p>
             <div class="tech-stack" style="margin-top:1rem;">
               <span class="tech-tag">AWS</span>

--- a/projects.html
+++ b/projects.html
@@ -393,7 +393,7 @@
       <p class="section-intro">Explore my work in cloud automation, security, and infrastructure.</p>
       
       <div class="project-card">
-        <h3>Website Hosting on GitHub and Route53</h3>
+        <h3>Website Hosting on GitHub and Route 53</h3>
         <p>This site is hosted using GitHub Pages, with a custom domain managed via Amazon Route 53. It's a fully static HTML/CSS portfolio built from scratch, designed to highlight my AWS DevOps work and learning journey in security and AI.</p>
         <div class="tech-stack" style="margin-top:1rem;">
           <span class="tech-tag">AWS Route 53</span>


### PR DESCRIPTION
## Summary
- fix typo in projects page project title from Route53 to Route 53
- update matching project card heading on home page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`
- `python3 -m http.server & curl -s http://localhost:8000/projects.html | grep -n 'Route 53'`
- `python3 -m http.server & curl -s http://localhost:8000/index.html | grep -n 'Route 53'`

------
https://chatgpt.com/codex/tasks/task_e_68947bdedebc83339de0ae69a7a3e4ba