### PR TITLE
Improve navigation consistency and add scroll-to-top

### DIFF
--- a/about.html
+++ b/about.html
@@ -270,6 +270,34 @@
       background: rgba(255,255,255,0.08);
     }
 
+    .scroll-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      background: var(--accent2);
+      color: var(--secondary);
+      border: none;
+      border-radius: 50%;
+      width: 48px;
+      height: 48px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 2rem;
+      box-shadow: var(--shadow);
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .3s, transform .3s;
+      z-index: 9999;
+      transform: translateY(40px);
+    }
+    .scroll-to-top.visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
+    }
+
     @media (max-width: 768px) {
       body {
         padding-top: 60px;
@@ -441,9 +469,9 @@
     </div>
   </main>
 
-  <footer>
-    <div class="container footer-content">
-      <p>&copy; <span id="copyright-year"></span> Nazli Singh — Built with 💻 and ☁️</p>
+    <footer>
+      <div class="container footer-content">
+        <p>&copy; <span id="copyright-year"></span> Nazli Singh — Built with 💻 and ☁️</p>
       <div class="footer-links">
         <a href="index.html">Home</a>
         <a href="about.html">About</a>
@@ -454,43 +482,68 @@
         <a href="https://github.com/naz26" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i> GitHub</a>
         <a href="https://www.linkedin.com/in/nazli-singh/" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin"></i> LinkedIn</a>
       </div>
+      </div>
+    </footer>
+    <div class="scroll-to-top" aria-label="Scroll to top" role="button" tabindex="0">
+      <i class="fas fa-chevron-up"></i>
     </div>
-  </footer>
 
-  <script>
-    document.getElementById('copyright-year').textContent = new Date().getFullYear();
-    
-    // Navigation auto-hide on mobile
-    let lastScrollTop = 0;
-    const navbar = document.getElementById('navbar');
-    
-    function handleNavScroll() {
-      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-      
-      if (window.innerWidth <= 768) {
-        if (scrollTop > lastScrollTop && scrollTop > 100) {
-          navbar.classList.add('nav-hidden');
+    <script>
+      document.getElementById('copyright-year').textContent = new Date().getFullYear();
+
+      const scrollToTopBtn = document.querySelector('.scroll-to-top');
+      const rootElement = document.documentElement;
+
+      function handleScroll() {
+        if (rootElement.scrollTop > 300) {
+          scrollToTopBtn.classList.add('visible');
         } else {
-          navbar.classList.remove('nav-hidden');
+          scrollToTopBtn.classList.remove('visible');
         }
       }
-      
-      lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
-    }
-    
-    function toggleNav() {
-      const navMenu = document.getElementById('nav-menu');
-      navMenu.classList.toggle('nav-open');
-    }
-    
-    // Close nav when clicking on a link
-    document.querySelectorAll('nav a').forEach(link => {
-      link.addEventListener('click', () => {
-        document.getElementById('nav-menu').classList.remove('nav-open');
+
+      function scrollToTop() {
+        rootElement.scrollTo({
+          top: 0,
+          behavior: 'smooth'
+        });
+      }
+
+      // Navigation auto-hide on mobile
+      let lastScrollTop = 0;
+      const navbar = document.getElementById('navbar');
+
+      function handleNavScroll() {
+        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+        if (window.innerWidth <= 768) {
+          if (scrollTop > lastScrollTop && scrollTop > 100) {
+            navbar.classList.add('nav-hidden');
+          } else {
+            navbar.classList.remove('nav-hidden');
+          }
+        }
+
+        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+      }
+
+      function toggleNav() {
+        const navMenu = document.getElementById('nav-menu');
+        navMenu.classList.toggle('nav-open');
+      }
+
+      document.querySelectorAll('nav a').forEach(link => {
+        link.addEventListener('click', () => {
+          document.getElementById('nav-menu').classList.remove('nav-open');
+        });
       });
-    });
-    
-    document.addEventListener('scroll', handleNavScroll);
-  </script>
-</body>
-</html>
+
+      document.addEventListener('scroll', handleScroll);
+      document.addEventListener('scroll', handleNavScroll);
+      scrollToTopBtn.addEventListener('click', scrollToTop);
+      document.querySelector('.scroll-to-top').addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') scrollToTop();
+      });
+    </script>
+  </body>
+  </html>

--- a/blog.html
+++ b/blog.html
@@ -295,6 +295,34 @@
       background: rgba(255,255,255,0.08);
     }
 
+    .scroll-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      background: var(--accent2);
+      color: var(--secondary);
+      border: none;
+      border-radius: 50%;
+      width: 48px;
+      height: 48px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 2rem;
+      box-shadow: var(--shadow);
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .3s, transform .3s;
+      z-index: 9999;
+      transform: translateY(40px);
+    }
+    .scroll-to-top.visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
+    }
+
     @media (max-width: 768px) {
       body {
         padding-top: 60px;
@@ -436,9 +464,9 @@
     </div>
   </main>
 
-  <footer>
-    <div class="container footer-content">
-      <p>&copy; <span id="copyright-year"></span> Nazli Singh — Built with 💻 and ☁️</p>
+    <footer>
+      <div class="container footer-content">
+        <p>&copy; <span id="copyright-year"></span> Nazli Singh — Built with 💻 and ☁️</p>
       <div class="footer-links">
         <a href="index.html">Home</a>
         <a href="about.html">About</a>
@@ -449,43 +477,68 @@
         <a href="https://github.com/naz26" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i> GitHub</a>
         <a href="https://www.linkedin.com/in/nazli-singh/" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin"></i> LinkedIn</a>
       </div>
+      </div>
+    </footer>
+    <div class="scroll-to-top" aria-label="Scroll to top" role="button" tabindex="0">
+      <i class="fas fa-chevron-up"></i>
     </div>
-  </footer>
 
-  <script>
-    document.getElementById('copyright-year').textContent = new Date().getFullYear();
-    
-    // Navigation auto-hide on mobile
-    let lastScrollTop = 0;
-    const navbar = document.getElementById('navbar');
-    
-    function handleNavScroll() {
-      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-      
-      if (window.innerWidth <= 768) {
-        if (scrollTop > lastScrollTop && scrollTop > 100) {
-          navbar.classList.add('nav-hidden');
+    <script>
+      document.getElementById('copyright-year').textContent = new Date().getFullYear();
+
+      const scrollToTopBtn = document.querySelector('.scroll-to-top');
+      const rootElement = document.documentElement;
+
+      function handleScroll() {
+        if (rootElement.scrollTop > 300) {
+          scrollToTopBtn.classList.add('visible');
         } else {
-          navbar.classList.remove('nav-hidden');
+          scrollToTopBtn.classList.remove('visible');
         }
       }
-      
-      lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
-    }
-    
-    function toggleNav() {
-      const navMenu = document.getElementById('nav-menu');
-      navMenu.classList.toggle('nav-open');
-    }
-    
-    // Close nav when clicking on a link
-    document.querySelectorAll('nav a').forEach(link => {
-      link.addEventListener('click', () => {
-        document.getElementById('nav-menu').classList.remove('nav-open');
+
+      function scrollToTop() {
+        rootElement.scrollTo({
+          top: 0,
+          behavior: 'smooth'
+        });
+      }
+
+      // Navigation auto-hide on mobile
+      let lastScrollTop = 0;
+      const navbar = document.getElementById('navbar');
+
+      function handleNavScroll() {
+        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+        if (window.innerWidth <= 768) {
+          if (scrollTop > lastScrollTop && scrollTop > 100) {
+            navbar.classList.add('nav-hidden');
+          } else {
+            navbar.classList.remove('nav-hidden');
+          }
+        }
+
+        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+      }
+
+      function toggleNav() {
+        const navMenu = document.getElementById('nav-menu');
+        navMenu.classList.toggle('nav-open');
+      }
+
+      document.querySelectorAll('nav a').forEach(link => {
+        link.addEventListener('click', () => {
+          document.getElementById('nav-menu').classList.remove('nav-open');
+        });
       });
-    });
-    
-    document.addEventListener('scroll', handleNavScroll);
-  </script>
-</body>
-</html>
+
+      document.addEventListener('scroll', handleScroll);
+      document.addEventListener('scroll', handleNavScroll);
+      scrollToTopBtn.addEventListener('click', scrollToTop);
+      document.querySelector('.scroll-to-top').addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') scrollToTop();
+      });
+    </script>
+  </body>
+  </html>

--- a/certification-diaries-aws-security.html
+++ b/certification-diaries-aws-security.html
@@ -225,9 +225,10 @@
     </button>
     <div class="container">
       <ul id="nav-menu">
+        <li><a href="index.html"><i class="fas fa-home"></i> Home</a></li>
         <li><a href="about.html"><i class="fas fa-user"></i> About</a></li>
         <li><a href="projects.html"><i class="fas fa-code"></i> Projects</a></li>
-        <li><a href="blog.html"><i class="fas fa-blog"></i> Blog</a></li>
+        <li class="active"><a href="blog.html"><i class="fas fa-blog"></i> Blog</a></li>
         <li><a href="creative.html"><i class="fas fa-paint-brush"></i> Creative</a></li>
         <li><a href="index.html#contact"><i class="fas fa-envelope"></i> Contact</a></li>
         <li>

--- a/cloud-cost-optimization.html
+++ b/cloud-cost-optimization.html
@@ -295,6 +295,34 @@
       background: rgba(255,255,255,0.08);
     }
 
+    .scroll-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      background: var(--accent2);
+      color: var(--secondary);
+      border: none;
+      border-radius: 50%;
+      width: 48px;
+      height: 48px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 2rem;
+      box-shadow: var(--shadow);
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .3s, transform .3s;
+      z-index: 9999;
+      transform: translateY(40px);
+    }
+    .scroll-to-top.visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
+    }
+
     @media (max-width: 768px) {
       body {
         padding-top: 60px;
@@ -423,9 +451,9 @@
     </div>
   </main>
 
-  <footer>
-    <div class="container footer-content">
-      <p>&copy; <span id="copyright-year"></span> Nazli Singh — Built with 💻 and ☁️</p>
+    <footer>
+      <div class="container footer-content">
+        <p>&copy; <span id="copyright-year"></span> Nazli Singh — Built with 💻 and ☁️</p>
       <div class="footer-links">
         <a href="index.html">Home</a>
         <a href="about.html">About</a>
@@ -436,43 +464,68 @@
         <a href="https://github.com/naz26" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i> GitHub</a>
         <a href="https://www.linkedin.com/in/nazli-singh/" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin"></i> LinkedIn</a>
       </div>
+      </div>
+    </footer>
+    <div class="scroll-to-top" aria-label="Scroll to top" role="button" tabindex="0">
+      <i class="fas fa-chevron-up"></i>
     </div>
-  </footer>
 
-  <script>
-    document.getElementById('copyright-year').textContent = new Date().getFullYear();
-    
-    // Navigation auto-hide on mobile
-    let lastScrollTop = 0;
-    const navbar = document.getElementById('navbar');
-    
-    function handleNavScroll() {
-      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-      
-      if (window.innerWidth <= 768) {
-        if (scrollTop > lastScrollTop && scrollTop > 100) {
-          navbar.classList.add('nav-hidden');
+    <script>
+      document.getElementById('copyright-year').textContent = new Date().getFullYear();
+
+      const scrollToTopBtn = document.querySelector('.scroll-to-top');
+      const rootElement = document.documentElement;
+
+      function handleScroll() {
+        if (rootElement.scrollTop > 300) {
+          scrollToTopBtn.classList.add('visible');
         } else {
-          navbar.classList.remove('nav-hidden');
+          scrollToTopBtn.classList.remove('visible');
         }
       }
-      
-      lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
-    }
-    
-    function toggleNav() {
-      const navMenu = document.getElementById('nav-menu');
-      navMenu.classList.toggle('nav-open');
-    }
-    
-    // Close nav when clicking on a link
-    document.querySelectorAll('nav a').forEach(link => {
-      link.addEventListener('click', () => {
-        document.getElementById('nav-menu').classList.remove('nav-open');
+
+      function scrollToTop() {
+        rootElement.scrollTo({
+          top: 0,
+          behavior: 'smooth'
+        });
+      }
+
+      // Navigation auto-hide on mobile
+      let lastScrollTop = 0;
+      const navbar = document.getElementById('navbar');
+
+      function handleNavScroll() {
+        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+        if (window.innerWidth <= 768) {
+          if (scrollTop > lastScrollTop && scrollTop > 100) {
+            navbar.classList.add('nav-hidden');
+          } else {
+            navbar.classList.remove('nav-hidden');
+          }
+        }
+
+        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+      }
+
+      function toggleNav() {
+        const navMenu = document.getElementById('nav-menu');
+        navMenu.classList.toggle('nav-open');
+      }
+
+      document.querySelectorAll('nav a').forEach(link => {
+        link.addEventListener('click', () => {
+          document.getElementById('nav-menu').classList.remove('nav-open');
+        });
       });
-    });
-    
-    document.addEventListener('scroll', handleNavScroll);
-  </script>
-</body>
-</html>
+
+      document.addEventListener('scroll', handleScroll);
+      document.addEventListener('scroll', handleNavScroll);
+      scrollToTopBtn.addEventListener('click', scrollToTop);
+      document.querySelector('.scroll-to-top').addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') scrollToTop();
+      });
+    </script>
+  </body>
+  </html>

--- a/creative.html
+++ b/creative.html
@@ -323,6 +323,34 @@
       background: rgba(255,255,255,0.08);
     }
 
+    .scroll-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      background: var(--accent2);
+      color: var(--secondary);
+      border: none;
+      border-radius: 50%;
+      width: 48px;
+      height: 48px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 2rem;
+      box-shadow: var(--shadow);
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .3s, transform .3s;
+      z-index: 9999;
+      transform: translateY(40px);
+    }
+    .scroll-to-top.visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
+    }
+
     @media (max-width: 768px) {
       body {
         padding-top: 60px;
@@ -523,9 +551,9 @@
     </div>
   </main>
 
-  <footer>
-    <div class="container footer-content">
-      <p>&copy; <span id="copyright-year"></span> Nazli Singh — Built with 💻 and ☁️</p>
+    <footer>
+      <div class="container footer-content">
+        <p>&copy; <span id="copyright-year"></span> Nazli Singh — Built with 💻 and ☁️</p>
       <div class="footer-links">
         <a href="index.html">Home</a>
         <a href="about.html">About</a>
@@ -536,43 +564,68 @@
         <a href="https://github.com/naz26" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i> GitHub</a>
         <a href="https://www.linkedin.com/in/nazli-singh/" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin"></i> LinkedIn</a>
       </div>
+      </div>
+    </footer>
+    <div class="scroll-to-top" aria-label="Scroll to top" role="button" tabindex="0">
+      <i class="fas fa-chevron-up"></i>
     </div>
-  </footer>
 
-  <script>
-    document.getElementById('copyright-year').textContent = new Date().getFullYear();
-    
-    // Navigation auto-hide on mobile
-    let lastScrollTop = 0;
-    const navbar = document.getElementById('navbar');
-    
-    function handleNavScroll() {
-      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-      
-      if (window.innerWidth <= 768) {
-        if (scrollTop > lastScrollTop && scrollTop > 100) {
-          navbar.classList.add('nav-hidden');
+    <script>
+      document.getElementById('copyright-year').textContent = new Date().getFullYear();
+
+      const scrollToTopBtn = document.querySelector('.scroll-to-top');
+      const rootElement = document.documentElement;
+
+      function handleScroll() {
+        if (rootElement.scrollTop > 300) {
+          scrollToTopBtn.classList.add('visible');
         } else {
-          navbar.classList.remove('nav-hidden');
+          scrollToTopBtn.classList.remove('visible');
         }
       }
-      
-      lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
-    }
-    
-    function toggleNav() {
-      const navMenu = document.getElementById('nav-menu');
-      navMenu.classList.toggle('nav-open');
-    }
-    
-    // Close nav when clicking on a link
-    document.querySelectorAll('nav a').forEach(link => {
-      link.addEventListener('click', () => {
-        document.getElementById('nav-menu').classList.remove('nav-open');
+
+      function scrollToTop() {
+        rootElement.scrollTo({
+          top: 0,
+          behavior: 'smooth'
+        });
+      }
+
+      // Navigation auto-hide on mobile
+      let lastScrollTop = 0;
+      const navbar = document.getElementById('navbar');
+
+      function handleNavScroll() {
+        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+        if (window.innerWidth <= 768) {
+          if (scrollTop > lastScrollTop && scrollTop > 100) {
+            navbar.classList.add('nav-hidden');
+          } else {
+            navbar.classList.remove('nav-hidden');
+          }
+        }
+
+        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+      }
+
+      function toggleNav() {
+        const navMenu = document.getElementById('nav-menu');
+        navMenu.classList.toggle('nav-open');
+      }
+
+      document.querySelectorAll('nav a').forEach(link => {
+        link.addEventListener('click', () => {
+          document.getElementById('nav-menu').classList.remove('nav-open');
+        });
       });
-    });
-    
-    document.addEventListener('scroll', handleNavScroll);
-  </script>
-</body>
-</html>
+
+      document.addEventListener('scroll', handleScroll);
+      document.addEventListener('scroll', handleNavScroll);
+      scrollToTopBtn.addEventListener('click', scrollToTop);
+      document.querySelector('.scroll-to-top').addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') scrollToTop();
+      });
+    </script>
+  </body>
+  </html>

--- a/index.html
+++ b/index.html
@@ -617,83 +617,7 @@
       margin-top: 0.5rem;
     }
   </style>
-<script>
-  // on load, apply saved theme
-  const root = document.documentElement;
-  if (localStorage.theme === "dark") root.setAttribute("data-theme","dark");
-
-  // toggle handler
-  function toggleTheme(){
-    if (root.getAttribute("data-theme")==="dark"){
-      root.removeAttribute("data-theme");
-      localStorage.removeItem("theme");
-    } else {
-      root.setAttribute("data-theme","dark");
-      localStorage.theme = "dark";
-    }
-  }
-
-  // Scroll to top button
-  const scrollToTopBtn = document.querySelector('.scroll-to-top');
-  const rootElement = document.documentElement;
-
-  function handleScroll() {
-    // Show or hide the button based on scroll position
-    if (rootElement.scrollTop > 300) {
-      scrollToTopBtn.classList.add('visible');
-    } else {
-      scrollToTopBtn.classList.remove('visible');
-    }
-  }
-
-  function scrollToTop() {
-    // Smooth scroll to top
-    rootElement.scrollTo({
-      top: 0,
-      behavior: 'smooth'
-    });
-  }
-
-  // Navigation auto-hide on mobile
-  let lastScrollTop = 0;
-  const navbar = document.getElementById('navbar');
-  
-  function handleNavScroll() {
-    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-    
-    if (window.innerWidth <= 768) {
-      if (scrollTop > lastScrollTop && scrollTop > 100) {
-        navbar.classList.add('nav-hidden');
-      } else {
-        navbar.classList.remove('nav-hidden');
-      }
-    }
-    
-    lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
-  }
-  
-  function toggleNav() {
-    const navMenu = document.getElementById('nav-menu');
-    navMenu.classList.toggle('nav-open');
-  }
-  
-  // Close nav when clicking on a link
-  document.querySelectorAll('nav a').forEach(link => {
-    link.addEventListener('click', () => {
-      document.getElementById('nav-menu').classList.remove('nav-open');
-    });
-  });
-
-  // Event listeners
-  document.addEventListener('scroll', handleScroll);
-  document.addEventListener('scroll', handleNavScroll);
-  scrollToTopBtn.addEventListener('click', scrollToTop);
-  // Accessibility: allow scroll-to-top button to be triggered by keyboard
-  document.querySelector('.scroll-to-top').addEventListener('keydown', function(e) {
-    if (e.key === 'Enter' || e.key === ' ') scrollToTop();
-  });
-</script>
-</head>
+  </head>
 <body>
   <div id="top"></div>
   <header>
@@ -719,6 +643,7 @@
         <i class="fas fa-bars"></i>
       </button>
       <ul id="nav-menu">
+        <li class="active"><a href="index.html"><i class="fas fa-home"></i> Home</a></li>
         <li><a href="about.html"><i class="fas fa-user"></i> About</a></li>
         <li><a href="projects.html"><i class="fas fa-code"></i> Projects</a></li>
         <li><a href="blog.html"><i class="fas fa-blog"></i> Blog</a></li>
@@ -912,7 +837,73 @@
   </div>
 
   <script>
+    const root = document.documentElement;
+    if (localStorage.theme === "dark") root.setAttribute("data-theme","dark");
+
+    function toggleTheme(){
+      if (root.getAttribute("data-theme")==="dark"){
+        root.removeAttribute("data-theme");
+        localStorage.removeItem("theme");
+      } else {
+        root.setAttribute("data-theme","dark");
+        localStorage.theme = "dark";
+      }
+    }
+
     document.getElementById('copyright-year').textContent = new Date().getFullYear();
+
+    const scrollToTopBtn = document.querySelector('.scroll-to-top');
+    const rootElement = document.documentElement;
+
+    function handleScroll() {
+      if (rootElement.scrollTop > 300) {
+        scrollToTopBtn.classList.add('visible');
+      } else {
+        scrollToTopBtn.classList.remove('visible');
+      }
+    }
+
+    function scrollToTop() {
+      rootElement.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+      });
+    }
+
+    let lastScrollTop = 0;
+    const navbar = document.getElementById('navbar');
+
+    function handleNavScroll() {
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+      if (window.innerWidth <= 768) {
+        if (scrollTop > lastScrollTop && scrollTop > 100) {
+          navbar.classList.add('nav-hidden');
+        } else {
+          navbar.classList.remove('nav-hidden');
+        }
+      }
+
+      lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+    }
+
+    function toggleNav() {
+      const navMenu = document.getElementById('nav-menu');
+      navMenu.classList.toggle('nav-open');
+    }
+
+    document.querySelectorAll('nav a').forEach(link => {
+      link.addEventListener('click', () => {
+        document.getElementById('nav-menu').classList.remove('nav-open');
+      });
+    });
+
+    document.addEventListener('scroll', handleScroll);
+    document.addEventListener('scroll', handleNavScroll);
+    scrollToTopBtn.addEventListener('click', scrollToTop);
+    document.querySelector('.scroll-to-top').addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' || e.key === ' ') scrollToTop();
+    });
   </script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -284,6 +284,34 @@
       background: rgba(255,255,255,0.08);
     }
 
+    .scroll-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      background: var(--accent2);
+      color: var(--secondary);
+      border: none;
+      border-radius: 50%;
+      width: 48px;
+      height: 48px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 2rem;
+      box-shadow: var(--shadow);
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .3s, transform .3s;
+      z-index: 9999;
+      transform: translateY(40px);
+    }
+    .scroll-to-top.visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
+    }
+
     @media (max-width: 768px) {
       body {
         padding-top: 60px;
@@ -444,9 +472,9 @@
     </div>
   </main>
 
-  <footer>
-    <div class="container footer-content">
-      <p>&copy; <span id="copyright-year"></span> Nazli Singh — Built with 💻 and ☁️</p>
+    <footer>
+      <div class="container footer-content">
+        <p>&copy; <span id="copyright-year"></span> Nazli Singh — Built with 💻 and ☁️</p>
       <div class="footer-links">
         <a href="index.html">Home</a>
         <a href="about.html">About</a>
@@ -457,43 +485,68 @@
         <a href="https://github.com/naz26" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i> GitHub</a>
         <a href="https://www.linkedin.com/in/nazli-singh/" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin"></i> LinkedIn</a>
       </div>
+      </div>
+    </footer>
+    <div class="scroll-to-top" aria-label="Scroll to top" role="button" tabindex="0">
+      <i class="fas fa-chevron-up"></i>
     </div>
-  </footer>
 
-  <script>
-    document.getElementById('copyright-year').textContent = new Date().getFullYear();
-    
-    // Navigation auto-hide on mobile
-    let lastScrollTop = 0;
-    const navbar = document.getElementById('navbar');
-    
-    function handleNavScroll() {
-      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-      
-      if (window.innerWidth <= 768) {
-        if (scrollTop > lastScrollTop && scrollTop > 100) {
-          navbar.classList.add('nav-hidden');
+    <script>
+      document.getElementById('copyright-year').textContent = new Date().getFullYear();
+
+      const scrollToTopBtn = document.querySelector('.scroll-to-top');
+      const rootElement = document.documentElement;
+
+      function handleScroll() {
+        if (rootElement.scrollTop > 300) {
+          scrollToTopBtn.classList.add('visible');
         } else {
-          navbar.classList.remove('nav-hidden');
+          scrollToTopBtn.classList.remove('visible');
         }
       }
-      
-      lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
-    }
-    
-    function toggleNav() {
-      const navMenu = document.getElementById('nav-menu');
-      navMenu.classList.toggle('nav-open');
-    }
-    
-    // Close nav when clicking on a link
-    document.querySelectorAll('nav a').forEach(link => {
-      link.addEventListener('click', () => {
-        document.getElementById('nav-menu').classList.remove('nav-open');
+
+      function scrollToTop() {
+        rootElement.scrollTo({
+          top: 0,
+          behavior: 'smooth'
+        });
+      }
+
+      // Navigation auto-hide on mobile
+      let lastScrollTop = 0;
+      const navbar = document.getElementById('navbar');
+
+      function handleNavScroll() {
+        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+        if (window.innerWidth <= 768) {
+          if (scrollTop > lastScrollTop && scrollTop > 100) {
+            navbar.classList.add('nav-hidden');
+          } else {
+            navbar.classList.remove('nav-hidden');
+          }
+        }
+
+        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+      }
+
+      function toggleNav() {
+        const navMenu = document.getElementById('nav-menu');
+        navMenu.classList.toggle('nav-open');
+      }
+
+      document.querySelectorAll('nav a').forEach(link => {
+        link.addEventListener('click', () => {
+          document.getElementById('nav-menu').classList.remove('nav-open');
+        });
       });
-    });
-    
-    document.addEventListener('scroll', handleNavScroll);
-  </script>
-</body>
-</html>
+
+      document.addEventListener('scroll', handleScroll);
+      document.addEventListener('scroll', handleNavScroll);
+      scrollToTopBtn.addEventListener('click', scrollToTop);
+      document.querySelector('.scroll-to-top').addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') scrollToTop();
+      });
+    </script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- add Home link to navigation across site for consistent menu structure
- implement scroll-to-top controls and supporting scripts on secondary pages
- consolidate theme and navigation scripts at page bottom for better flow

## Testing
- `sudo apt-get update` *(fails: repository InRelease not signed)*
- `npx -y htmlhint index.html` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68977f308ac08333938de8a5a866697c