### PR TITLE
Add hero header, calming fonts, and featured gallery

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -6,6 +6,9 @@
   <meta name="description" content="{{ site.description }}">
   <link rel="canonical" href="{{ page.url | url | absoluteUrl(site.url) }}">
   <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="{{ site.title }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;700&family=Fira+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/style.css">
   <script defer data-domain="nazliinthecloud.com" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -16,6 +19,9 @@
     <a href="/blog/">Blog</a>
     <a href="/contact/">Contact</a>
   </nav>
+  <header class="hero">
+    <img src="/assets/header.svg" alt="Sky with sun" />
+  </header>
   <main>
     {{ content | safe }}
   </main>

--- a/src/assets/header.svg
+++ b/src/assets/header.svg
@@ -1,0 +1,11 @@
+<svg width="1200" height="400" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#bde0fe"/>
+      <stop offset="100%" stop-color="#e8f0ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="400" fill="url(#sky)"/>
+  <circle cx="1000" cy="120" r="80" fill="#ffb703"/>
+  <rect y="360" width="1200" height="40" fill="#023047"/>
+</svg>

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,17 +1,27 @@
 :root {
-  --bg: #f5f5f0;
-  --fg: #222;
-  --accent: #6b705c;
+  /* Colors sampled from header.svg */
+  --bg: #e8f0ff;
+  --fg: #023047;
+  --accent: #ffb703;
 }
 
 body {
   background: var(--bg);
   color: var(--fg);
-  font-family: system-ui, sans-serif;
+  font-family: 'Nunito Sans', sans-serif;
   line-height: 1.6;
   margin: 0 auto;
   max-width: 42rem;
   padding: 1rem;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Fira Mono', monospace;
 }
 
 nav a {
@@ -22,4 +32,22 @@ nav a {
 
 nav a:hover {
   text-decoration: underline;
+}
+
+.hero img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.gallery img {
+  width: 100%;
+  height: auto;
+  display: block;
 }

--- a/src/index.njk
+++ b/src/index.njk
@@ -5,3 +5,21 @@ permalink: /
 ---
 <h1>Welcome</h1>
 <p>Hello, I'm Nazli. This is my corner of the internet.</p>
+
+<section class="featured">
+  <h2>Featured</h2>
+  <div class="gallery">
+    <figure class="item">
+      <img src="https://via.placeholder.com/300x200?text=Project+1" alt="Project 1">
+      <figcaption>Project 1</figcaption>
+    </figure>
+    <figure class="item">
+      <img src="https://via.placeholder.com/300x200?text=Project+2" alt="Project 2">
+      <figcaption>Project 2</figcaption>
+    </figure>
+    <figure class="item">
+      <img src="https://via.placeholder.com/300x200?text=Project+3" alt="Project 3">
+      <figcaption>Project 3</figcaption>
+    </figure>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- Sample header illustration to derive new `--bg`, `--fg`, and `--accent` colors in stylesheet.
- Import Nunito Sans and Fira Mono, applying them to body text and headings.
- Introduce hero header image and featured gallery grid on the home page layout.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898e844ce8c8333b329fe42cce114d8